### PR TITLE
Refactor state

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,32 +52,32 @@ Objects have a few configurable settings:
 
 Objects can emit a reward when the agent collides with them by specifying the `reward` function:
 ```python
-def reward(self, rng: np.random.Generator, clock: int):
+def reward(self, s: ForagerState):
     # objects are *not* notified at every clock cycle, but can
     # simulate the passage of time by tracking how long since last contact
-    time_since_last_collision = clock - self.last_collision
+    time_since_last_collision = s.clock - self.last_collision
     r = np.sin(time_since_last_collision)
 
     # objects are handed an rng owned by the global environment
     # this can be used in combination with `clock` for simulations
     # or to add noise to the reward signal
-    eps = rng.normal(0, 1)
+    eps = s.rng.normal(0, 1)
     return r + eps
 ```
 
 Finally, objects can control how much time passes until they respawn:
 ```python
-def regen_delay(self, rng: np.random.Generator, clock: int):
+def regen_delay(self, s: ForagerState):
     # prevents the object from respawning, this object is permanently removed changing the env forever
     # use with caution!
     return None
 
 # default implementation:
-def regen_delay(self, rng: np.random.Generator, clock: int):
+def regen_delay(self, s: ForagerState):
     # a random number of timesteps into the future before the object reappears
     # self.location can be modified here to control _where_ the object reappears
     # otherwise if self.location is None, then the object will be randomly placed
-    return rng.integers(10, 100)
+    return s.rng.integers(10, 100)
 ```
 
 ## Design philosophy

--- a/forager/Env.py
+++ b/forager/Env.py
@@ -1,18 +1,12 @@
-import numpy as np
-import numba as nb
 import forager._utils.numba as nbu
-import forager._utils.config as cu
 import forager.grid as grid
-
-from collections import defaultdict
-from typing import Dict, List
 
 from forager.config import ForagerConfig, load_config, sanity_check
 from forager.exceptions import ForagerInvalidConfigException
-from forager.interface import Action, Coords, Size
+from forager.interface import Action, Coords
 from forager.objects import ForagerObject
-from forager.ObjectStorage import ObjectStorage
 from forager.observations import get_object_vision, get_color_vision, get_world_vision
+from forager.state import ForagerState
 
 
 class ForagerEnv:
@@ -28,10 +22,10 @@ class ForagerEnv:
         # parse configuration
         config = sanity_check(config)
         self._c = config
-        self._s = _ForagerState(config)
+        self._s = ForagerState(config)
 
     def start(self):
-        return self._get_observation(self._s.agent_state)
+        return self._get_observation()
 
     def step(self, action: Action):
         n = grid.step(self._s.agent_state, self._s.size, action)
@@ -48,12 +42,11 @@ class ForagerEnv:
             if obj.collectable:
                 self.remove_object(n)
 
-        obs = self._get_observation(n)
-
         self._s.agent_state = n
         self._s.clock += 1
-        self._respawn()
 
+        obs = self._get_observation()
+        self._respawn()
         return (obs, float(r))
 
     def add_object(self, obj: ForagerObject):
@@ -81,15 +74,13 @@ class ForagerEnv:
 
         del self._s.to_respawn[self._s.clock]
 
-    def _get_observation(self, s: Coords):
+    def _get_observation(self):
         if self._c.observation_mode == 'objects':
-            assert self._s.ap_size is not None, "Expected non-none aperture size when observation mode is 'objects'"
-            return get_object_vision(s, self._s.size, self._s.ap_size, self._s.objects.idx_to_name, self._s.names_to_dims)
+            return get_object_vision(self._s)
         elif self._c.observation_mode == 'colors':
-            assert self._s.ap_size is not None, "Expected non-none aperture size when observation mode is 'colors'"
-            return get_color_vision(s, self._s.size, self._s.ap_size, self._s.objects.idx_to_name, self._s.objects.name_to_color)
+            return get_color_vision(self._s)
         elif self._c.observation_mode == 'world':
-            return get_world_vision(s, self._s.size, self._s.objects.idx_to_name, self._s.names_to_dims)
+            return get_world_vision(self._s)
         else:
             raise Exception()
 
@@ -100,46 +91,3 @@ class ForagerEnv:
 
     def __setstate__(self, state):
         ...
-
-
-class _ForagerState:
-    def __init__(
-        self,
-        config: ForagerConfig,
-    ):
-        self.config = config
-        self.rng = np.random.default_rng(config.seed)
-
-        # parse config
-        self.size: Size = cu.to_tuple(config.size)
-        self.ap_size = cu.to_tuple(config.aperture) if config.aperture is not None else None
-
-        # build object storage
-        self.colors = cu.not_none(config.colors)
-        self.objects = ObjectStorage(self.size, config.object_types, self.colors, self.rng)
-
-        # build respawn timers
-        self.to_respawn: Dict[int, List[ForagerObject]] = defaultdict(list)
-
-        # ensure object types have a consistent object dimension
-        _names = set(config.object_types.keys())
-
-        if config.observation_mode == 'world':
-            _names |= {'agent'}
-
-        self.names = nbu.List(sorted(_names))
-        self.names_to_dims = nbu.Dict.empty(
-            key_type=nb.typeof(''),
-            value_type=nb.typeof(int(1)),
-            n_keys=len(_names),
-        )
-
-        for i, n in enumerate(self.names):
-            self.names_to_dims[n] = i
-
-        # build state information
-        self.clock = 0
-        self.agent_state = (
-            int(self.size[0] // 2),
-            int(self.size[1] // 2),
-        )

--- a/forager/Env.py
+++ b/forager/Env.py
@@ -1,5 +1,6 @@
 import forager._utils.numba as nbu
 import forager.grid as grid
+import forager.ObjectStorage as obj_store
 
 from forager.config import ForagerConfig, load_config, sanity_check
 from forager.exceptions import ForagerInvalidConfigException
@@ -32,8 +33,8 @@ class ForagerEnv:
         idx = nbu.ravel(n, self._s.size)
 
         r = 0.
-        if self._s.objects.has_object(idx):
-            obj = self._s.objects.get_object(idx)
+        if obj_store.has_object(self._s, idx):
+            obj = obj_store.get_object(self._s, idx)
             r = obj.collision(self._s)
 
             if obj.blocking:
@@ -50,15 +51,15 @@ class ForagerEnv:
         return (obs, float(r))
 
     def add_object(self, obj: ForagerObject):
-        self._s.objects.add_object(obj)
+        obj_store.add_object(self._s, obj)
 
     def generate_objects(self, freq: float, name: str):
         size = self._s.size[0] * self._s.size[1]
-        self._s.objects.add_n_deferred_objects(name, int(size * freq))
+        obj_store.add_n_deferred_objects(self._s, name, int(size * freq))
 
     def remove_object(self, coords: Coords):
         idx = nbu.ravel(coords, self._s.size)
-        obj = self._s.objects.remove_object(idx)
+        obj = obj_store.remove_object(self._s, idx)
 
         delta = obj.regen_delay(self._s)
 
@@ -70,7 +71,7 @@ class ForagerEnv:
             return
 
         for obj in self._s.to_respawn[self._s.clock]:
-            self._s.objects.add_object(obj)
+            obj_store.add_object(self._s, obj)
 
         del self._s.to_respawn[self._s.clock]
 

--- a/forager/Env.py
+++ b/forager/Env.py
@@ -34,7 +34,7 @@ class ForagerEnv:
         r = 0.
         if self._s.objects.has_object(idx):
             obj = self._s.objects.get_object(idx)
-            r = obj.collision(self._s.rng, self._s.clock)
+            r = obj.collision(self._s)
 
             if obj.blocking:
                 n = self._s.agent_state
@@ -60,7 +60,7 @@ class ForagerEnv:
         idx = nbu.ravel(coords, self._s.size)
         obj = self._s.objects.remove_object(idx)
 
-        delta = obj.regen_delay(self._s.rng, self._s.clock)
+        delta = obj.regen_delay(self._s)
 
         if delta is not None:
             self._s.to_respawn[self._s.clock + delta].append(obj)

--- a/forager/objects.py
+++ b/forager/objects.py
@@ -1,7 +1,13 @@
-import numpy as np
-
+from __future__ import annotations
 from abc import abstractmethod
 from forager.interface import Coords, RawRGB
+
+# we have some unfortunate circular imports here
+# this ensures that the cycle only exists at type-checking
+# time instead of at runtime.
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from forager.state import ForagerState
 
 class ForagerObject:
     def __init__(self, name: str):
@@ -14,16 +20,16 @@ class ForagerObject:
 
         self.last_collision = 0
 
-    def regen_delay(self, rng: np.random.Generator, clock: int) -> int | None:
-        return rng.integers(10, 100)
+    def regen_delay(self, state: ForagerState) -> int | None:
+        return state.rng.integers(10, 100)
 
-    def collision(self, rng: np.random.Generator, clock: int) -> float:
-        r = self.reward(rng, clock)
-        self.last_collision = clock
+    def collision(self, state: ForagerState) -> float:
+        r = self.reward(state)
+        self.last_collision = state.clock
         return r
 
     @abstractmethod
-    def reward(self, rng: np.random.Generator, clock: int) -> float:
+    def reward(self, state: ForagerState) -> float:
         raise NotImplementedError()
 
 
@@ -35,7 +41,7 @@ class Wall(ForagerObject):
         self.collectable = False
         self.location = loc
 
-    def reward(self, rng: np.random.Generator, clock: int) -> float:
+    def reward(self, state: ForagerState) -> float:
         return 0
 
 class Flower(ForagerObject):
@@ -46,7 +52,7 @@ class Flower(ForagerObject):
         self.collectable = True
         self.location = loc
 
-    def reward(self, rng: np.random.Generator, clock: int) -> float:
+    def reward(self, state: ForagerState) -> float:
         return 1
 
 class Thorns(ForagerObject):
@@ -57,5 +63,5 @@ class Thorns(ForagerObject):
         self.collectable = True
         self.location = loc
 
-    def reward(self, rng: np.random.Generator, clock: int) -> float:
+    def reward(self, state: ForagerState) -> float:
         return -1

--- a/forager/observations.py
+++ b/forager/observations.py
@@ -3,10 +3,20 @@ import forager._utils.numba as nbu
 
 from typing import Dict
 from forager.interface import Coords, Size
+from forager.state import ForagerState
 
+def get_color_vision(s: ForagerState):
+    assert s.ap_size is not None, "Expected non-none aperture size when observation mode is 'colors'"
+    return _get_color_vision(
+        s.agent_state,
+        s.size,
+        s.ap_size,
+        s.objects.idx_to_name,
+        s.objects.name_to_color,
+    )
 
 @nbu.njit
-def get_color_vision(
+def _get_color_vision(
     state: Coords,
     size: Size,
     ap_size: Size,
@@ -38,8 +48,19 @@ def get_color_vision(
     return out
 
 
+def get_object_vision(s: ForagerState):
+    assert s.ap_size is not None, "Expected non-none aperture size when observation mode is 'objects'"
+    return _get_object_vision(
+        s.agent_state,
+        s.size,
+        s.ap_size,
+        s.objects.idx_to_name,
+        s.names_to_dims,
+    )
+
+
 @nbu.njit
-def get_object_vision(
+def _get_object_vision(
     state: Coords,
     size: Size,
     ap_size: Size,
@@ -71,8 +92,18 @@ def get_object_vision(
 
     return out
 
+
+def get_world_vision(s: ForagerState):
+    return _get_world_vision(
+        s.agent_state,
+        s.size,
+        s.objects.idx_to_name,
+        s.names_to_dims,
+    )
+
+
 @nbu.njit
-def get_world_vision(
+def _get_world_vision(
     state: Coords,
     size: Size,
     objs: Dict[Coords, str],

--- a/forager/state.py
+++ b/forager/state.py
@@ -9,7 +9,6 @@ from typing import Dict, List
 from forager.config import ForagerConfig
 from forager.interface import Size
 from forager.objects import ForagerObject
-from forager.ObjectStorage import ObjectStorage
 
 class ForagerState:
     def __init__(
@@ -25,7 +24,7 @@ class ForagerState:
 
         # build object storage
         self.colors = cu.not_none(config.colors)
-        self.objects = ObjectStorage(self.size, config.object_types, self.colors, self.rng)
+        self.objects = ObjectStoreState()
 
         # build respawn timers
         self.to_respawn: Dict[int, List[ForagerObject]] = defaultdict(list)
@@ -52,3 +51,21 @@ class ForagerState:
             int(self.size[0] // 2),
             int(self.size[1] // 2),
         )
+
+
+class ObjectStoreState:
+    def __init__(self) -> None:
+        self.idx_to_name = nbu.Dict.empty(
+            key_type=nb.types.int64,
+            value_type=nb.typeof(''),
+        )
+
+        self.name_to_color = nbu.Dict.empty(
+            key_type=nb.typeof(''),
+            value_type=nb.types.uint8[:],
+        )
+
+        self.idx_to_object: Dict[int, ForagerObject] = {}
+
+    def __len__(self) -> int:
+        return len(self.idx_to_name)

--- a/forager/state.py
+++ b/forager/state.py
@@ -1,0 +1,54 @@
+import numpy as np
+import numba as nb
+import forager._utils.numba as nbu
+import forager._utils.config as cu
+
+from collections import defaultdict
+from typing import Dict, List
+
+from forager.config import ForagerConfig
+from forager.interface import Size
+from forager.objects import ForagerObject
+from forager.ObjectStorage import ObjectStorage
+
+class ForagerState:
+    def __init__(
+        self,
+        config: ForagerConfig,
+    ):
+        self.config = config
+        self.rng = np.random.default_rng(config.seed)
+
+        # parse config
+        self.size: Size = cu.to_tuple(config.size)
+        self.ap_size = cu.to_tuple(config.aperture) if config.aperture is not None else None
+
+        # build object storage
+        self.colors = cu.not_none(config.colors)
+        self.objects = ObjectStorage(self.size, config.object_types, self.colors, self.rng)
+
+        # build respawn timers
+        self.to_respawn: Dict[int, List[ForagerObject]] = defaultdict(list)
+
+        # ensure object types have a consistent object dimension
+        _names = set(config.object_types.keys())
+
+        if config.observation_mode == 'world':
+            _names |= {'agent'}
+
+        self.names = nbu.List(sorted(_names))
+        self.names_to_dims = nbu.Dict.empty(
+            key_type=nb.typeof(''),
+            value_type=nb.typeof(int(1)),
+            n_keys=len(_names),
+        )
+
+        for i, n in enumerate(self.names):
+            self.names_to_dims[n] = i
+
+        # build state information
+        self.clock = 0
+        self.agent_state = (
+            int(self.size[0] // 2),
+            int(self.size[1] // 2),
+        )

--- a/tests/test_Env.py
+++ b/tests/test_Env.py
@@ -20,9 +20,9 @@ def test_init():
     )
     env = ForagerEnv(config)
 
-    assert env._state == (4, 4)
-    assert env._size == (8, 8)
-    assert env._ap_size == (3, 3)
+    assert env._s.agent_state == (4, 4)
+    assert env._s.size == (8, 8)
+    assert env._s.ap_size == (3, 3)
 
     # can specify sizes as uneven tuples
     config = ForagerConfig(
@@ -32,9 +32,9 @@ def test_init():
     )
     env = ForagerEnv(config)
 
-    assert env._state == (5, 2)
-    assert env._size == (10, 5)
-    assert env._ap_size == (5, 1)
+    assert env._s.agent_state == (5, 2)
+    assert env._s.size == (10, 5)
+    assert env._s.ap_size == (5, 1)
 
     # can add objects
     config = ForagerConfig(
@@ -46,7 +46,7 @@ def test_init():
     env = ForagerEnv(config)
     env.generate_objects(0.1, 'flower')
 
-    assert len(env._obj_store) == int(100 * 0.1)
+    assert len(env._s.objects) == int(100 * 0.1)
 
     # world observation mode, apeture should be None
     config = ForagerConfig(
@@ -56,7 +56,7 @@ def test_init():
     )
     env = ForagerEnv(config)
 
-    assert env._ap_size is None
+    assert env._s.ap_size is None
 
 def test_basic_movement():
     config = ForagerConfig(
@@ -69,20 +69,20 @@ def test_basic_movement():
     env.add_object(Wall((3, 4)))
     env.add_object(Wall((3, 5)))
 
-    assert env._state == (3, 3)
+    assert env._s.agent_state == (3, 3)
 
     # stays still when bumping into a wall
     _ = env.step(0)
-    assert env._state == (3, 3)
+    assert env._s.agent_state == (3, 3)
 
     _ = env.step(1)
-    assert env._state == (4, 3)
+    assert env._s.agent_state == (4, 3)
 
     _ = env.step(3)
-    assert env._state == (3, 3)
+    assert env._s.agent_state == (3, 3)
 
     _ = env.step(2)
-    assert env._state == (3, 2)
+    assert env._s.agent_state == (3, 2)
 
 def test_vision():
     config = ForagerConfig(
@@ -97,7 +97,7 @@ def test_vision():
     env.add_object(Wall((3, 5)))
     env.add_object(Wall((0, 2)))
 
-    assert env._state == (3, 3)
+    assert env._s.agent_state == (3, 3)
 
     x, _ = env.step(0)
     expected = np.array([
@@ -106,7 +106,7 @@ def test_vision():
         [0, 0, 0],
     ], dtype=np.bool_)
 
-    assert env._state == (3, 3)
+    assert env._s.agent_state == (3, 3)
     assert np.allclose(x[:, :, 0], expected)
 
     env.step(1)
@@ -117,7 +117,7 @@ def test_vision():
         [0, 0, 0],
     ], dtype=np.bool_)
 
-    assert env._state == (4, 4)
+    assert env._s.agent_state == (4, 4)
     assert np.allclose(x[:, :, 0], expected)
 
 def test_respawn():
@@ -131,24 +131,24 @@ def test_respawn():
     )
     env = ForagerEnv(config)
     env.add_object(Flower((3, 4)))
-    assert len(env._to_respawn) == 0
+    assert len(env._s.to_respawn) == 0
 
     _, r = env.step(0)
     assert r == 1
-    assert len(env._obj_store) == 0
-    assert len(env._to_respawn) == 1
-    assert env._clock == 1
+    assert len(env._s.objects) == 0
+    assert len(env._s.to_respawn) == 1
+    assert env._s.clock == 1
 
     for _ in range(50):
         env.step(0)
 
-    assert len(env._to_respawn) == 1
-    assert env._clock == 51
+    assert len(env._s.to_respawn) == 1
+    assert env._s.clock == 51
 
     env.step(0)
-    assert env._clock == 52
-    assert len(env._obj_store) == 1
-    assert len(env._to_respawn) == 0
+    assert env._s.clock == 52
+    assert len(env._s.objects) == 1
+    assert len(env._s.to_respawn) == 0
 
 def test_wrapping_dynamics():
     config = ForagerConfig(
@@ -162,59 +162,59 @@ def test_wrapping_dynamics():
 
     # go up
     _ = env.start()
-    assert env._state == (2, 2)
+    assert env._s.agent_state == (2, 2)
     _ = env.step(0)
-    assert env._state == (2, 3)
+    assert env._s.agent_state == (2, 3)
     _ = env.step(0)
-    assert env._state == (2, 4)
+    assert env._s.agent_state == (2, 4)
     _ = env.step(0)
-    assert env._state == (2, 0)
+    assert env._s.agent_state == (2, 0)
     _ = env.step(0)
-    assert env._state == (2, 1)
+    assert env._s.agent_state == (2, 1)
     _ = env.step(0)
-    assert env._state == (2, 2)
+    assert env._s.agent_state == (2, 2)
 
     # go down
     _ = env.start()
-    assert env._state == (2, 2)
+    assert env._s.agent_state == (2, 2)
     _ = env.step(2)
-    assert env._state == (2, 1)
+    assert env._s.agent_state == (2, 1)
     _ = env.step(2)
-    assert env._state == (2, 0)
+    assert env._s.agent_state == (2, 0)
     _ = env.step(2)
-    assert env._state == (2, 4)
+    assert env._s.agent_state == (2, 4)
     _ = env.step(2)
-    assert env._state == (2, 3)
+    assert env._s.agent_state == (2, 3)
     _ = env.step(2)
-    assert env._state == (2, 2)
+    assert env._s.agent_state == (2, 2)
 
     # go right
     _ = env.start()
-    assert env._state == (2, 2)
+    assert env._s.agent_state == (2, 2)
     _ = env.step(1)
-    assert env._state == (3, 2)
+    assert env._s.agent_state == (3, 2)
     _ = env.step(1)
-    assert env._state == (4, 2)
+    assert env._s.agent_state == (4, 2)
     _ = env.step(1)
-    assert env._state == (0, 2)
+    assert env._s.agent_state == (0, 2)
     _ = env.step(1)
-    assert env._state == (1, 2)
+    assert env._s.agent_state == (1, 2)
     _ = env.step(1)
-    assert env._state == (2, 2)
+    assert env._s.agent_state == (2, 2)
 
     # go left
     _ = env.start()
-    assert env._state == (2, 2)
+    assert env._s.agent_state == (2, 2)
     _ = env.step(3)
-    assert env._state == (1, 2)
+    assert env._s.agent_state == (1, 2)
     _ = env.step(3)
-    assert env._state == (0, 2)
+    assert env._s.agent_state == (0, 2)
     _ = env.step(3)
-    assert env._state == (4, 2)
+    assert env._s.agent_state == (4, 2)
     _ = env.step(3)
-    assert env._state == (3, 2)
+    assert env._s.agent_state == (3, 2)
     _ = env.step(3)
-    assert env._state == (2, 2)
+    assert env._s.agent_state == (2, 2)
 
 def test_wrapping_vision():
     config = ForagerConfig(
@@ -236,7 +236,7 @@ def test_wrapping_vision():
 
     x = env.start()
 
-    assert env._state == (2, 2)
+    assert env._s.agent_state == (2, 2)
     assert np.allclose(x[:, :, 0], expected)
 
     # go left
@@ -250,7 +250,7 @@ def test_wrapping_vision():
         [1, 0, 0],
     ], dtype=np.bool_)
 
-    assert env._state == (1, 1)
+    assert env._s.agent_state == (1, 1)
     assert np.allclose(x[:, :, 0], expected)
 
     # go left , go left
@@ -262,7 +262,7 @@ def test_wrapping_vision():
         [0, 0, 1],
     ], dtype=np.bool_)
 
-    assert env._state == (4, 1)
+    assert env._s.agent_state == (4, 1)
     assert np.allclose(x[:, :, 0], expected)
 
 
@@ -282,7 +282,7 @@ def test_benchmark_vision(benchmark):
     env.add_object(Wall((3, 5)))
     env.add_object(Wall((0, 2)))
 
-    assert env._state == (3, 3)
+    assert env._s.agent_state == (3, 3)
 
     x, _ = benchmark(env.step, 0)
     expected = np.array([
@@ -291,7 +291,7 @@ def test_benchmark_vision(benchmark):
         [0, 0, 0],
     ], dtype=np.bool_)
 
-    assert env._state == (3, 3)
+    assert env._s.agent_state == (3, 3)
     assert np.allclose(x[:, :, 0], expected)
 
 def test_benchmark_creation(benchmark):

--- a/tests/test_observations.py
+++ b/tests/test_observations.py
@@ -2,7 +2,7 @@ import numpy as np
 import numba as nb
 import forager._utils.numba as nbu
 
-from forager.observations import get_color_vision, get_object_vision, get_world_vision
+from forager.observations import _get_color_vision, _get_object_vision, _get_world_vision
 
 
 def test_color_vision():
@@ -31,7 +31,7 @@ def test_color_vision():
     name_to_color['a'] = a
     name_to_color['b'] = b
 
-    got = get_color_vision(state, size, ap_size, idx_to_name, name_to_color)
+    got = _get_color_vision(state, size, ap_size, idx_to_name, name_to_color)
     expected = np.array([
         [e, b, e],
         [e, e, e],
@@ -62,7 +62,7 @@ def test_object_vision():
     idx_to_name[nbu.ravel((3, 4), size)] = 'a'
     idx_to_name[nbu.ravel((5, 5), size)] = 'a'
     idx_to_name[nbu.ravel((6, 5), size)] = 'b'
-    got = get_object_vision((5, 5), size, ap_size, idx_to_name, name_to_dim)
+    got = _get_object_vision((5, 5), size, ap_size, idx_to_name, name_to_dim)
     assert got.shape[2] == 2
 
     expected_a = np.array([
@@ -100,7 +100,7 @@ def test_object_vision_wrap():
 
     idx_to_name[nbu.ravel((3, 0), size)] = 'a'
     idx_to_name[nbu.ravel((0, 3), size)] = 'b'
-    got = get_object_vision((3, 4), size, ap_size, idx_to_name, name_to_dim)
+    got = _get_object_vision((3, 4), size, ap_size, idx_to_name, name_to_dim)
     assert got.shape[2] == 2
 
     expected_a = np.array([
@@ -111,7 +111,7 @@ def test_object_vision_wrap():
 
     assert np.allclose(got[:, :, 0], expected_a)
 
-    got = get_object_vision((4, 3), size, ap_size, idx_to_name, name_to_dim)
+    got = _get_object_vision((4, 3), size, ap_size, idx_to_name, name_to_dim)
     assert got.shape[2] == 2
 
     expected_b = np.array([
@@ -142,7 +142,7 @@ def test_world_vision():
     idx_to_name[nbu.ravel((2, 2), size)] = 'a'
     idx_to_name[nbu.ravel((3, 1), size)] = 'a'
     idx_to_name[nbu.ravel((3, 0), size)] = 'b'
-    got = get_world_vision((3, 1), size, idx_to_name, name_to_dim)
+    got = _get_world_vision((3, 1), size, idx_to_name, name_to_dim)
 
     excepted_agent = np.array([
         [0, 0, 0, 0],


### PR DESCRIPTION
This change puts all of the environment stateful information into a single object which can be passed around to several subsystems. This will make it much easier to implement differential observations for performance, but also enables us to pass complete state information into the `ForagerObjects` allowing for _much_ more powerful custom objects.

Technically this is a breaking change because the custom `ForagerObjects` API changes. I don't believe we are currently using this API.