### PR TITLE
feat: add current object location to obj state

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Objects have a few configurable settings:
 * `blocking` prevents the agent from occupying the same space as the object (think: wall)
 * `collectable` means the object is removed when the agent collides. By default, collected objects are respawned after some delay.
 * `color` specifies a color for the object class. **Note:** currently can only specify one color per _class_.
-* `location` allows controlling the specific location of an object. If unspecified, object is placed uniform randomly.
+* `target_location` allows controlling the specific location of an object. If unspecified, object is placed uniform randomly.
 
 Objects can emit a reward when the agent collides with them by specifying the `reward` function:
 ```python

--- a/forager/ObjectStorage.py
+++ b/forager/ObjectStorage.py
@@ -29,10 +29,11 @@ class ObjectStorage:
         self._colors = palette
 
     def add_object(self, obj: ForagerObject):
-        coords = obj.location
+        coords = obj.target_location
         if coords is None:
             coords = grid.sample_unpopulated(self.rng, self.size, self.idx_to_name)
 
+        obj.current_location = coords
         idx = nbu.ravel(coords, self.size)
 
         if idx in self.idx_to_name:
@@ -79,6 +80,9 @@ class ObjectStorage:
         name = self.idx_to_name[idx]
         obj = self.factories[name]()
         self._idx_to_config[idx] = obj
+
+        coords = nbu.unravel(idx, self.size)
+        obj.current_location = coords
 
         return obj
 

--- a/forager/objects.py
+++ b/forager/objects.py
@@ -9,7 +9,8 @@ class ForagerObject:
 
         self.collectable: bool = True
         self.blocking: bool = False
-        self.location: Coords | None = None
+        self.target_location: Coords | None = None
+        self.current_location: Coords | None = None
         self.color: RawRGB | None = None
 
         self.last_collision = 0
@@ -33,7 +34,7 @@ class Wall(ForagerObject):
 
         self.blocking = True
         self.collectable = False
-        self.location = loc
+        self.target_location = loc
 
     def reward(self, rng: np.random.Generator, clock: int) -> float:
         return 0
@@ -44,7 +45,7 @@ class Flower(ForagerObject):
 
         self.blocking = False
         self.collectable = True
-        self.location = loc
+        self.target_location = loc
 
     def reward(self, rng: np.random.Generator, clock: int) -> float:
         return 1
@@ -55,7 +56,7 @@ class Thorns(ForagerObject):
 
         self.blocking = False
         self.collectable = True
-        self.location = loc
+        self.target_location = loc
 
     def reward(self, rng: np.random.Generator, clock: int) -> float:
         return -1

--- a/tests/test_Env.py
+++ b/tests/test_Env.py
@@ -265,6 +265,26 @@ def test_wrapping_vision():
     assert env._state == (4, 1)
     assert np.allclose(x[:, :, 0], expected)
 
+def test_object_location():
+    config = ForagerConfig(
+        size=5,
+        object_types={
+            'flower': Flower,
+        },
+        aperture=3
+    )
+    env = ForagerEnv(config)
+    f = Flower((2, 0))
+    assert f.target_location == (2, 0)
+    env.add_object(f)
+
+    env.start()
+    _, r = env.step(2)
+    _, r = env.step(2)
+    assert r == 1
+    assert f.current_location == (2, 0)
+
+
 def test_checkpointing():
     config = ForagerConfig(
         size=5,


### PR DESCRIPTION
BREAKING CHANGE: in order to distinguish between a target location and the actual current location, it seemed like a good idea to rename the ambiguous `location` attribute. Unfortunately this is a public API change.